### PR TITLE
Fix defmethod

### DIFF
--- a/aria2.el
+++ b/aria2.el
@@ -177,10 +177,10 @@ See aria2c manual for supported options."
     "Return base64-encoded string with contents of file on PATH."
     (unless (file-exists-p path)
         (signal 'aria2-err-file-doesnt-exist '(path)))
-    (with-current-buffer (find-file-noselect path)
-        (unwind-protect
-            (base64-encode-string (buffer-string) t)
-            (kill-buffer))))
+    (with-temp-buffer
+        (insert-file-contents-literally path)
+        (base64-encode-region (point-min) (point-max) t)
+        (buffer-string)))
 
 (defun aria2--is-aria-process-p (pid)
     "Returns t if `process-attributes' of PID belongs to aria."


### PR DESCRIPTION
`defmethod` is obsolete and removed from recent emacs versions. Replace it with `cl-defmethod`.

`find-file-noselect` reuses already existing buffer which causes bad UX for the user. Proper way is to use temp buffer which doesn't show up anywhere.
